### PR TITLE
Enhance branding, FAQ info and enquiry options

### DIFF
--- a/axon_site/contact.html
+++ b/axon_site/contact.html
@@ -46,6 +46,14 @@
       <input type="text" id="name" name="name" required>
       <label for="email">Email</label>
       <input type="email" id="email" name="_replyto" required>
+      <label for="purpose">Purpose of enquiry</label>
+      <select id="purpose" name="purpose">
+        <option value="purchase">Purchase of own home</option>
+        <option value="investment">Investment property</option>
+        <option value="refinance">Refinance</option>
+        <option value="general">General information</option>
+        <option value="other">Other</option>
+      </select>
       <label for="message">Message</label>
       <textarea id="message" name="message" rows="5" required></textarea>
       <button type="submit" class="cta-button">Send Message</button>

--- a/axon_site/faq.html
+++ b/axon_site/faq.html
@@ -44,7 +44,7 @@
       </details>
       <details>
         <summary>Do I need a 20&#x202f;% deposit to buy a home?</summary>
-        <p>While a 20&#x202f;% deposit is ideal, there are options for lower deposits. Lenders mortgage insurance may apply on loans above 80&#x202f;% of the property value. We’ll explain deposit requirements and the pros and cons of different structures.</p>
+        <p>While a 20&#x202f;% deposit is ideal, there are options for lower deposits. Some lenders even waive Lenders Mortgage Insurance (LMI) for certain professions, allowing deposits as low as 5&#x202f;%. <a href="contact.html">Contact us</a> to see if you qualify and to understand the pros and cons of different structures.</p>
       </details>
       <details>
         <summary>What documentation do I need for loan pre‑approval?</summary>
@@ -60,7 +60,7 @@
       </details>
       <details>
         <summary>Do your services cost anything?</summary>
-        <p>In most cases our service is at no cost to you — we receive a commission from the lender once your loan settles. If any fees do apply, we’ll disclose them upfront so there are no surprises.</p>
+        <p>Our service is free to you — we’re paid a commission by the lender when your loan settles.</p>
       </details>
     </div>
   </section>

--- a/axon_site/index.html
+++ b/axon_site/index.html
@@ -126,6 +126,14 @@
         <input type="text" id="home-name" name="name" required>
         <label for="home-email">Email</label>
         <input type="email" id="home-email" name="_replyto" required>
+        <label for="home-purpose">Purpose of enquiry</label>
+        <select id="home-purpose" name="purpose">
+          <option value="purchase">Purchase of own home</option>
+          <option value="investment">Investment property</option>
+          <option value="refinance">Refinance</option>
+          <option value="general">General information</option>
+          <option value="other">Other</option>
+        </select>
         <label for="home-message">Message</label>
         <textarea id="home-message" name="message" rows="5" required></textarea>
         <button type="submit" class="cta-button">Send Message</button>

--- a/axon_site/services/index.html
+++ b/axon_site/services/index.html
@@ -43,6 +43,7 @@
 
   <section class="section container">
     <h2>Explore Our Specialties</h2>
+    <p>We specialise in assisting medical professionals and defence personnel, yet offer professional mortgage guidance to clients from all backgrounds.</p>
     <div class="services-grid">
       <div class="service-card">
         <h3><a href="home-loan-selection.html">Home Loan Selection</a></h3>

--- a/axon_site/style.css
+++ b/axon_site/style.css
@@ -95,9 +95,9 @@ nav {
 
 /* logo icon inside the nav */
 .logo-icon {
-  /* Increase the logo size to occupy roughly 75% of the banner height */
-  width: 48px;
-  height: 48px;
+  /* Make the logo noticeably larger than the brand text */
+  height: 2.4rem; /* 150% of the surrounding text size */
+  width: auto;
   margin-right: 0.5rem;
 }
 
@@ -300,11 +300,15 @@ nav {
 }
 
 .contact-form input,
-.contact-form textarea {
+.contact-form textarea,
+.contact-form select {
   padding: 0.75rem;
   border: 1px solid #ccc;
   border-radius: 4px;
   font-size: 1rem;
+}
+
+.contact-form textarea {
   resize: vertical;
 }
 
@@ -368,6 +372,7 @@ nav {
 .faq-list summary {
   font-weight: 600;
   cursor: pointer;
+  color: var(--primary-color);
 }
 
 .faq-list p {

--- a/axon_site/team.html
+++ b/axon_site/team.html
@@ -40,7 +40,7 @@
     <div class="services-grid" style="grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));">
       <div class="service-card">
         <h3>Bradley Burns</h3>
-        <p><strong>Founder &amp; Principal Broker</strong><br>Bradley brings over a decade of experience in finance and specialises in helping defence personnel and healthcare professionals. He’s passionate about demystifying the mortgage process and empowering clients to make informed decisions.</p>
+        <p><strong>Founder &amp; Principal Broker</strong><br>Bradley brings over a decade of experience in finance and specialises in helping defence personnel and healthcare professionals, while providing professional guidance to clients from all backgrounds. He’s passionate about demystifying the mortgage process and empowering clients to make informed decisions.</p>
       </div>
     </div>
     <p style="margin-top:2rem;"><a href="contact.html" class="cta-button">Book a Consultation</a></p>


### PR DESCRIPTION
## Summary
- Enlarge navigation logo to stand out against the Axon Financial Group text
- Use brand colour for FAQ questions and clarify no-cost service and LMI waivers with contact CTA
- Add enquiry-purpose dropdowns to contact forms and note specialties while welcoming all clients

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897397d1f08832282332abee01f19e0