### PR TITLE
Add in-house mortgage calculators

### DIFF
--- a/axon_site/calculators.html
+++ b/axon_site/calculators.html
@@ -44,33 +44,74 @@
   <section class="section container">
     <h2>Borrowing Capacity</h2>
     <p>Get an indication of how much you could borrow based on your income and expenses.</p>
-    <div id="calc-borrowing" style="margin-bottom:2rem;">
-      <iframe src="https://embed.quickli.com.au/placeholder-borrowing" title="Borrowing Capacity Calculator" width="100%" height="600" style="border:0; border-radius:8px; max-width:100%;"></iframe>
-    </div>
+    <form id="borrow-form" class="calculator">
+      <label for="income">Annual income (before tax)</label>
+      <input type="number" id="income" min="0" required>
+      <label for="expenses">Monthly expenses</label>
+      <input type="number" id="expenses" min="0" required>
+      <label for="bc-rate">Interest rate (%)</label>
+      <input type="number" id="bc-rate" step="0.01" min="0" required>
+      <label for="bc-term">Loan term (years)</label>
+      <input type="number" id="bc-term" min="1" required>
+      <button type="submit">Calculate</button>
+      <div class="calculator-result" id="borrow-result"></div>
+    </form>
 
     <h2>Repayment Calculator</h2>
     <p>Estimate your repayments for different loan amounts and terms.</p>
-    <div id="calc-repayment" style="margin-bottom:2rem;">
-      <iframe src="https://embed.quickli.com.au/placeholder-repayment" title="Loan Repayment Calculator" width="100%" height="600" style="border:0; border-radius:8px; max-width:100%;"></iframe>
-    </div>
+    <form id="repay-form" class="calculator">
+      <label for="loan-amount">Loan amount</label>
+      <input type="number" id="loan-amount" min="0" required>
+      <label for="repay-rate">Interest rate (%)</label>
+      <input type="number" id="repay-rate" step="0.01" min="0" required>
+      <label for="repay-term">Loan term (years)</label>
+      <input type="number" id="repay-term" min="1" required>
+      <button type="submit">Calculate</button>
+      <div class="calculator-result" id="repay-result"></div>
+    </form>
 
     <h2>Refinance Savings</h2>
     <p>Explore how refinancing could reduce your monthly repayments.</p>
-    <div id="calc-refinance" style="margin-bottom:2rem;">
-      <iframe src="https://embed.quickli.com.au/placeholder-refinance" title="Refinance Calculator" width="100%" height="600" style="border:0; border-radius:8px; max-width:100%;"></iframe>
-    </div>
+    <form id="refi-form" class="calculator">
+      <label for="refi-amount">Loan amount</label>
+      <input type="number" id="refi-amount" min="0" required>
+      <label for="current-rate">Current interest rate (%)</label>
+      <input type="number" id="current-rate" step="0.01" min="0" required>
+      <label for="new-rate">New interest rate (%)</label>
+      <input type="number" id="new-rate" step="0.01" min="0" required>
+      <label for="refi-term">Remaining term (years)</label>
+      <input type="number" id="refi-term" min="1" required>
+      <button type="submit">Calculate</button>
+      <div class="calculator-result" id="refi-result"></div>
+    </form>
 
     <h2>Investment Property ROI</h2>
     <p>Analyse potential rental income and expenses to assess your investment’s cash flow.</p>
-    <div id="calc-investment" style="margin-bottom:2rem;">
-      <iframe src="https://embed.quickli.com.au/placeholder-investment" title="Investment Property Calculator" width="100%" height="600" style="border:0; border-radius:8px; max-width:100%;"></iframe>
-    </div>
+    <form id="invest-form" class="calculator">
+      <label for="property-price">Property price</label>
+      <input type="number" id="property-price" min="0" required>
+      <label for="rent">Monthly rent</label>
+      <input type="number" id="rent" min="0" required>
+      <label for="invest-expenses">Monthly expenses</label>
+      <input type="number" id="invest-expenses" min="0" required>
+      <button type="submit">Calculate</button>
+      <div class="calculator-result" id="invest-result"></div>
+    </form>
 
     <h2>Deposit Savings Target</h2>
     <p>Set a deposit goal and see how much you need to save each month to reach it by a given date.</p>
-    <div id="calc-deposit" style="margin-bottom:2rem;">
-      <iframe src="https://embed.quickli.com.au/placeholder-deposit" title="Deposit Savings Calculator" width="100%" height="600" style="border:0; border-radius:8px; max-width:100%;"></iframe>
-    </div>
+    <form id="deposit-form" class="calculator">
+      <label for="target">Target amount</label>
+      <input type="number" id="target" min="0" required>
+      <label for="current">Current savings</label>
+      <input type="number" id="current" min="0" value="0" required>
+      <label for="deposit-years">Timeframe (years)</label>
+      <input type="number" id="deposit-years" min="1" required>
+      <label for="deposit-rate">Annual interest rate (%)</label>
+      <input type="number" id="deposit-rate" step="0.01" min="0" value="0" required>
+      <button type="submit">Calculate</button>
+      <div class="calculator-result" id="deposit-result"></div>
+    </form>
   </section>
 
   <section class="section" style="text-align:center;">
@@ -88,5 +129,6 @@
       <p>© 2025 Axon Financial Group. All rights reserved.</p>
     </div>
   </footer>
+  <script src="calculators.js"></script>
 </body>
 </html>

--- a/axon_site/calculators.js
+++ b/axon_site/calculators.js
@@ -1,0 +1,88 @@
+function formatCurrency(value) {
+  return new Intl.NumberFormat('en-AU', { style: 'currency', currency: 'AUD' }).format(value);
+}
+
+function loanPayment(amount, annualRate, years) {
+  const r = annualRate / 100 / 12;
+  const n = years * 12;
+  if (r === 0) {
+    return amount / n;
+  }
+  return amount * r / (1 - Math.pow(1 + r, -n));
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const borrowForm = document.getElementById('borrow-form');
+  borrowForm.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const income = parseFloat(document.getElementById('income').value) || 0;
+    const expenses = parseFloat(document.getElementById('expenses').value) || 0;
+    const rate = parseFloat(document.getElementById('bc-rate').value) || 0;
+    const term = parseInt(document.getElementById('bc-term').value) || 0;
+    const monthlyAvailable = Math.max(0, income / 12 - expenses);
+    const r = rate / 100 / 12;
+    const n = term * 12;
+    let borrow = 0;
+    if (r > 0) {
+      borrow = monthlyAvailable * (1 - Math.pow(1 + r, -n)) / r;
+    } else {
+      borrow = monthlyAvailable * n;
+    }
+    document.getElementById('borrow-result').textContent = 'Estimated borrowing capacity: ' + formatCurrency(borrow);
+  });
+
+  const repayForm = document.getElementById('repay-form');
+  repayForm.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const amount = parseFloat(document.getElementById('loan-amount').value) || 0;
+    const rate = parseFloat(document.getElementById('repay-rate').value) || 0;
+    const term = parseInt(document.getElementById('repay-term').value) || 0;
+    const payment = loanPayment(amount, rate, term);
+    document.getElementById('repay-result').textContent = 'Estimated monthly repayment: ' + formatCurrency(payment);
+  });
+
+  const refiForm = document.getElementById('refi-form');
+  refiForm.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const amount = parseFloat(document.getElementById('refi-amount').value) || 0;
+    const currentRate = parseFloat(document.getElementById('current-rate').value) || 0;
+    const newRate = parseFloat(document.getElementById('new-rate').value) || 0;
+    const term = parseInt(document.getElementById('refi-term').value) || 0;
+    const currentPayment = loanPayment(amount, currentRate, term);
+    const newPayment = loanPayment(amount, newRate, term);
+    const monthlySaving = currentPayment - newPayment;
+    const totalSaving = monthlySaving * term * 12;
+    document.getElementById('refi-result').textContent =
+      'Monthly saving: ' + formatCurrency(monthlySaving) + ' | Total saving: ' + formatCurrency(totalSaving);
+  });
+
+  const investForm = document.getElementById('invest-form');
+  investForm.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const price = parseFloat(document.getElementById('property-price').value) || 0;
+    const rent = parseFloat(document.getElementById('rent').value) || 0;
+    const expenses = parseFloat(document.getElementById('invest-expenses').value) || 0;
+    const annualNet = (rent - expenses) * 12;
+    const roi = price > 0 ? (annualNet / price) * 100 : 0;
+    document.getElementById('invest-result').textContent =
+      'Annual cash flow: ' + formatCurrency(annualNet) + ' | ROI: ' + roi.toFixed(2) + '%';
+  });
+
+  const depositForm = document.getElementById('deposit-form');
+  depositForm.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const target = parseFloat(document.getElementById('target').value) || 0;
+    const current = parseFloat(document.getElementById('current').value) || 0;
+    const years = parseInt(document.getElementById('deposit-years').value) || 0;
+    const rate = parseFloat(document.getElementById('deposit-rate').value) || 0;
+    const n = years * 12;
+    const r = rate / 100 / 12;
+    let monthlySaving = 0;
+    if (r > 0) {
+      monthlySaving = (target - current * Math.pow(1 + r, n)) * r / (Math.pow(1 + r, n) - 1);
+    } else {
+      monthlySaving = (target - current) / n;
+    }
+    document.getElementById('deposit-result').textContent = 'Required monthly saving: ' + formatCurrency(monthlySaving);
+  });
+});

--- a/axon_site/style.css
+++ b/axon_site/style.css
@@ -448,4 +448,44 @@ nav {
   .nav-social {
     display: flex;
   }
+}/* Calculator styles */
+.calculator {
+  background-color: var(--light-bg);
+  padding: 1rem;
+  margin-bottom: 2rem;
+  border-radius: 8px;
+}
+
+.calculator label {
+  font-weight: 600;
+}
+
+.calculator input,
+.calculator select {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 1rem;
+  width: 100%;
+  margin-bottom: 0.5rem;
+}
+
+.calculator button {
+  background-color: var(--primary-color);
+  color: var(--light-text);
+  border: none;
+  padding: 0.75rem;
+  border-radius: 4px;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background 0.3s;
+}
+
+.calculator button:hover {
+  background-color: var(--secondary-color);
+}
+
+.calculator-result {
+  font-weight: 600;
+  margin-top: 0.5rem;
 }


### PR DESCRIPTION
## Summary
- Replace Quickli iframes with branded forms for five mortgage calculators and load new script.
- Implement calculators.js providing borrowing capacity, repayment, refinance savings, ROI, and deposit goal calculations.
- Add matching CSS for calculator layout and buttons.

## Testing
- `npm test` (fails: Could not read package.json)
- `node --check axon_site/calculators.js`


------
https://chatgpt.com/codex/tasks/task_e_68973f7560508322833ee7156c7631bf