### PR TITLE
Fix broken mortgage calculator page

### DIFF
--- a/axon_site/mortgage-calculator.html
+++ b/axon_site/mortgage-calculator.html
@@ -7,12 +7,9 @@
   <meta name="description" content="Mortgage calculators by Axon Financial Group: repayments, refinance savings, and borrowing power." />
 
   <!-- Axon site styles (optional but recommended for global look) -->
-  <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="style.css">
 
-  <!-- Calculator styles (root) -->
-  <link rel="stylesheet" href="/calc-suite.css">
-
-  <link rel="icon" type="image/png" href="/assets/favicon.png" />
+  <link rel="icon" type="image/png" href="assets/favicon.png" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&display=swap" rel="stylesheet">
@@ -39,8 +36,112 @@
     <h1 class="page-title">Financial Calculators</h1>
     <p class="lead">Estimate repayments, model refinance savings, and understand borrowing power — all in one place.</p>
 
-    <!-- Calculator mount point -->
-    <div id="mortgage-calculator"></div>
+    <h2><i class="fas fa-wallet" aria-hidden="true"></i> Borrowing Capacity</h2>
+    <p>Get an indication of how much you could borrow based on your income and expenses.</p>
+    <form id="borrow-form" class="calculator">
+      <div class="form-group">
+        <label for="income">Annual income (before tax)</label>
+        <input type="number" id="income" min="0" required>
+      </div>
+      <div class="form-group">
+        <label for="expenses">Monthly expenses</label>
+        <input type="number" id="expenses" min="0" required>
+      </div>
+      <div class="form-group">
+        <label for="bc-rate">Interest rate (%)</label>
+        <input type="number" id="bc-rate" step="0.01" min="0" required>
+      </div>
+      <div class="form-group">
+        <label for="bc-term">Loan term (years)</label>
+        <input type="number" id="bc-term" min="1" required>
+      </div>
+      <button type="submit">Calculate</button>
+      <div class="calculator-result" id="borrow-result"></div>
+    </form>
+
+    <h2><i class="fas fa-calculator" aria-hidden="true"></i> Repayment Calculator</h2>
+    <p>Estimate your repayments for different loan amounts and terms.</p>
+    <form id="repay-form" class="calculator">
+      <div class="form-group">
+        <label for="loan-amount">Loan amount</label>
+        <input type="number" id="loan-amount" min="0" required>
+      </div>
+      <div class="form-group">
+        <label for="repay-rate">Interest rate (%)</label>
+        <input type="number" id="repay-rate" step="0.01" min="0" required>
+      </div>
+      <div class="form-group">
+        <label for="repay-term">Loan term (years)</label>
+        <input type="number" id="repay-term" min="1" required>
+      </div>
+      <button type="submit">Calculate</button>
+      <div class="calculator-result" id="repay-result"></div>
+    </form>
+
+    <h2><i class="fas fa-sync-alt" aria-hidden="true"></i> Refinance Savings</h2>
+    <p>Explore how refinancing could reduce your monthly repayments.</p>
+    <form id="refi-form" class="calculator">
+      <div class="form-group">
+        <label for="refi-amount">Loan amount</label>
+        <input type="number" id="refi-amount" min="0" required>
+      </div>
+      <div class="form-group">
+        <label for="current-rate">Current interest rate (%)</label>
+        <input type="number" id="current-rate" step="0.01" min="0" required>
+      </div>
+      <div class="form-group">
+        <label for="new-rate">New interest rate (%)</label>
+        <input type="number" id="new-rate" step="0.01" min="0" required>
+      </div>
+      <div class="form-group">
+        <label for="refi-term">Remaining term (years)</label>
+        <input type="number" id="refi-term" min="1" required>
+      </div>
+      <button type="submit">Calculate</button>
+      <div class="calculator-result" id="refi-result"></div>
+    </form>
+
+    <h2><i class="fas fa-chart-line" aria-hidden="true"></i> Investment Property ROI</h2>
+    <p>Analyse potential rental income and expenses to assess your investment’s cash flow.</p>
+    <form id="invest-form" class="calculator">
+      <div class="form-group">
+        <label for="property-price">Property price</label>
+        <input type="number" id="property-price" min="0" required>
+      </div>
+      <div class="form-group">
+        <label for="rent">Monthly rent</label>
+        <input type="number" id="rent" min="0" required>
+      </div>
+      <div class="form-group">
+        <label for="invest-expenses">Monthly expenses</label>
+        <input type="number" id="invest-expenses" min="0" required>
+      </div>
+      <button type="submit">Calculate</button>
+      <div class="calculator-result" id="invest-result"></div>
+    </form>
+
+    <h2><i class="fas fa-piggy-bank" aria-hidden="true"></i> Deposit Savings Target</h2>
+    <p>Set a deposit goal and see how much you need to save each month to reach it by a given date.</p>
+    <form id="deposit-form" class="calculator">
+      <div class="form-group">
+        <label for="target">Target amount</label>
+        <input type="number" id="target" min="0" required>
+      </div>
+      <div class="form-group">
+        <label for="current">Current savings</label>
+        <input type="number" id="current" min="0" value="0" required>
+      </div>
+      <div class="form-group">
+        <label for="deposit-years">Timeframe (years)</label>
+        <input type="number" id="deposit-years" min="1" required>
+      </div>
+      <div class="form-group">
+        <label for="deposit-rate">Annual interest rate (%)</label>
+        <input type="number" id="deposit-rate" step="0.01" min="0" value="0" required>
+      </div>
+      <button type="submit">Calculate</button>
+      <div class="calculator-result" id="deposit-result"></div>
+    </form>
   </main>
 
   <footer class="footer">
@@ -50,19 +151,6 @@
       <p>&copy; 2025 Axon Financial Group. All rights reserved.</p>
     </div>
   </footer>
-
-  <!-- Dependencies (CDN) -->
-  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
-
-  <!-- Calculator logic (root) -->
-  <script src="/calc-suite.js"></script>
-  <script>
-    window.addEventListener('DOMContentLoaded', () => {
-      MortgageCalcSuite.mount('#mortgage-calculator', {
-        brandColor: '#0ea5e9',
-        onGetAdvice: () => location.href = '/thank-you.html'
-      });
-    });
-  </script>
+  <script src="calculators.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Inline mortgage calculator forms directly in `mortgage-calculator.html`
- Replace missing `calc-suite.js` reference with existing `calculators.js`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897e06ce7b8832293b1dc6a918e23e5